### PR TITLE
Add support for multiple outputs

### DIFF
--- a/dash_callback_chain/__init__.py
+++ b/dash_callback_chain/__init__.py
@@ -42,11 +42,13 @@ def dot_chain(app, excluded_callbacks = []):
         wrapped_func = callback['callback'].__wrapped__
         callback_name = wrapped_func.__name__
         if callback_name in excluded_callbacks: continue
-        output, output_prop = callback_id.split(".")
-        clusters[output].add(output_prop)
-        output_list.append('"%s" [shape=octagon];' % callback_name)
-        output_list.append('"%s" -> "%s.%s";' %
-            (callback_name, output, output_prop))
+        split_list = callback_id.split(".")
+        for output, output_prop in zip(split_list[0::2], split_list[1::2]):
+            if output != "" and output_prop != "":
+                clusters[output].add(output_prop)
+                output_list.append('"%s" [shape=octagon];' % callback_name)
+                output_list.append('"%s" -> "%s.%s";' %
+                    (callback_name, output, output_prop))
         for i in callback['inputs']:
             clusters[i['id']].add(i['property'])
             output_list.append('"%s.%s" -> "%s";' %


### PR DESCRIPTION
Multiple outputs give `callback_id` the following structure:
'..output1.output_prop1...output2.output_prop2...output3.output_prop3..'
for example:
'..reference_container.style...citation_container.style...list_container.style..'.
Splitting by `'.'` gives a list of pairs with empty string pairs between valid values.